### PR TITLE
CORS requires pre-flight OPTIONS method for "complex requests", i.e. PUT

### DIFF
--- a/jwt_proxy/api.py
+++ b/jwt_proxy/api.py
@@ -4,7 +4,7 @@ import requests
 import json
 
 blueprint = Blueprint('auth', __name__)
-SUPPORTED_METHODS = ('GET', 'POST', 'PUT', 'DELETE')
+SUPPORTED_METHODS = ('GET', 'POST', 'PUT', 'DELETE', 'OPTIONS')
 
 
 def proxy_request(req, upstream_url):


### PR DESCRIPTION
Complex requests include:
The CORS specification defines a complex request as

    A request that uses methods other than GET, POST, or HEAD
    A request that includes headers other than Accept, Accept-Language or Content-Language
    A request that has a Content-Type header other than application/x-www-form-urlencoded, multipart/form-data, or text/plain

[Pre-flighted request spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests)