### PR TITLE
pass XML through if given

### DIFF
--- a/jwt_proxy/api.py
+++ b/jwt_proxy/api.py
@@ -17,7 +17,7 @@ def proxy_request(req, upstream_url, user_info=None):
         headers=req.headers,
         params=req.args,
         json=req.json,
-        data=req.data
+        data=req.data,
     )
     try:
         result = response.json()

--- a/jwt_proxy/api.py
+++ b/jwt_proxy/api.py
@@ -17,6 +17,7 @@ def proxy_request(req, upstream_url, user_info=None):
         headers=req.headers,
         params=req.args,
         json=req.json,
+        data=req.data
     )
     try:
         result = response.json()


### PR DESCRIPTION
Include req.data in the requests data parameter in case the client is passing XML rather than the previously assumed JSON