### PR TITLE
Increase server timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV FLASK_APP=jwt_proxy.wsgi:app \
 
 EXPOSE "${PORT}"
 
-CMD gunicorn --bind "0.0.0.0:${PORT:-8008}" ${FLASK_APP}
+CMD gunicorn --bind "0.0.0.0:${PORT:-8008}" ${FLASK_APP} --timeout 180


### PR DESCRIPTION
Work around $summary timeouts to Hapi v8

Change gunicorn request timeout to 3 minutes (from 30 seconds)