### PR TITLE
Fix FHIR result filtering via transform_response

### DIFF
--- a/jwt_proxy/policies/05_allow_patient_summary.py
+++ b/jwt_proxy/policies/05_allow_patient_summary.py
@@ -121,7 +121,7 @@ def transform_response(request, response_body, user_info=None):
     
     # Only process Patient $summary or $everything requests
     if not _is_patient_summary_request(request):
-        return None
+        return response_body
     
     # Only process Bundle responses
     if not isinstance(response_body, dict) or response_body.get("resourceType") != "Bundle":


### PR DESCRIPTION
Issue raised in [this comment](https://github.com/uwcirg/jwt-proxy/pull/20/files#diff-28394a68e5f88316646be108f71ac0a491db6288346a8228ca1bed501989457dR246)

Based on [this line](https://github.com/uwcirg/jwt-proxy/blob/841ee5a9289a433c3bf1633de363a83af84a8bc4/jwt_proxy/policies/51_fhir_response_security.py#L141), transform_response should return an unmodified response body when deferring the policy.

- [x] Change return value for non-summary/everything requests in transformer
- [x] Test
- [x] Check that other instances of returning "None" are intended or if they should also be updated